### PR TITLE
Добавил .editorconfig

### DIFF
--- a/LessonMonitor/.editorconfig
+++ b/LessonMonitor/.editorconfig
@@ -1,0 +1,16 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+# Instance fields are camelCase and start with _
+
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _

--- a/LessonMonitor/LessonMonitor.sln
+++ b/LessonMonitor/LessonMonitor.sln
@@ -17,6 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LessonMonitor.DataAccess.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LessonMonitor.DataAccess.MSSQL", "LessonMonitor.DataAccess.MSSQL\LessonMonitor.DataAccess.MSSQL.csproj", "{1448C9F2-A9C0-4E81-9753-F04C56364269}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{733B504E-0280-4369-B6B2-8810D1EC5FAC}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Добавляет автоматическую генерацию нижнего подчеркивания для private readonly fields.
![image](https://user-images.githubusercontent.com/19328606/125609663-402b2667-cd9b-4480-aab8-dd6ee342bc88.png)

Подсмотрел здесь: https://ardalis.com/configure-visual-studio-to-name-private-fields-with-underscore/
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options?view=vs-2019
